### PR TITLE
feat: add Makefile for build automation and execution

### DIFF
--- a/TP2/Makefile
+++ b/TP2/Makefile
@@ -1,0 +1,72 @@
+# ==============================
+# CONFIG
+# ==============================
+
+CC = gcc
+CFLAGS = -Wall -Wextra -O0 -g
+ASFLAGS = --64 -g
+
+TARGET = c/program
+
+SRC_C = c/main_i2.c c/file_reader.c
+SRC_ASM = c/process_value.s
+
+OBJ = c/main_i2.o c/file_reader.o c/process_value.o
+
+DATA_FILE = data/gini_values.txt
+
+# ==============================
+# DEFAULT
+# ==============================
+
+all: run
+
+# ==============================
+# DATA GENERATION
+# ==============================
+
+$(DATA_FILE):
+	@echo "Generating data file..."
+	python3 python/data_formatter.py
+
+# ==============================
+# COMPILATION
+# ==============================
+
+c/main_i2.o: c/main_i2.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+c/file_reader.o: c/file_reader.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+c/process_value.o: c/process_value.s
+	as $(ASFLAGS) -o $@ $<
+
+# ==============================
+# LINKING
+# ==============================
+
+$(TARGET): $(OBJ)
+	$(CC) $(CFLAGS) -o $@ $(OBJ)
+
+# ==============================
+# RUN
+# ==============================
+
+run: $(DATA_FILE) $(TARGET)
+	@echo "Running program..."
+	./$(TARGET)
+
+# ==============================
+# DEBUG
+# ==============================
+
+debug: $(DATA_FILE) $(TARGET)
+	gdb ./$(TARGET)
+
+# ==============================
+# CLEAN
+# ==============================
+
+clean:
+	rm -f c/*.o $(TARGET)


### PR DESCRIPTION
## 🧩 Issue relacionada
Closes #22 

---

## 📄 Descripción
Se agrega un Makefile para automatizar el flujo de ejecución del proyecto, integrando:

- generación de datos desde Python
- compilación de C y Assembler
- linkeo del binario
- ejecución y debugging con GDB

Esto reemplaza el proceso manual y mejora la reproducibilidad del TP.

---

## ⚙️ Cambios realizados
- Se crea `Makefile` en la raíz del proyecto
- Se definen reglas de compilación para C (`.c → .o`)
- Se agrega ensamblado de ASM (`.s → .o`)
- Se incorpora generación automática de datos (`python/data_formatter.py`)
- Se agregan targets:
   - `make` (build + run)
   - `make debug` (ejecución con GDB)
   - `make clean` (limpieza de binarios)
---

## 🧪 Cómo probarlo
Pasos para ejecutar y verificar:

1. Ejecutar:
```bash
make
```
2. Verificar que:
   - se genera el archivo de datos
   - compila correctamente
   - ejecuta el programa  
3.  Probar debugging:
```bash
make debug
```

---

## ✅ Checklist
- [x] Compila correctamente
- [x] No rompe funcionalidad existente
- [x] Probado manualmente
- [x] Código formateado / limpio

---

## 🧱 Capa afectada
- [x] Python
- [x] C
- [x] Assembler
